### PR TITLE
Document branches for Xperia 1 VI and 10 VI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 | Branch | Device(s) | Platform | SoC |
 | --- | --- | --- | --- |
-| `58.x.A.x.xxx` | Xperia 1 II,  5 II  | edo     | SM8250 |
-| `61.x.A.x.xxx` | Xperia 1 III, 5 III | sagami  | SM8350 |
-| `62.x.A.x.xxx` | Xperia 10 III       | lena    | SM6350 |
-| `64.x.A.x.xxx` | Xperia 1 IV, 5 IV   | nagara  | SM8450 |
-| `65.x.A.x.xxx` | Xperia 10 IV        | murray  | SM6375 |
-| `67.x.A.x.xxx` | Xperia 1 V          | yodo    | SM8550 |
-| `68.x.A.x.xxx` | Xperia 10 V         | zambezi | SM6375 |
+| `58.x.A.x.xxx` | Xperia 1 II,  5 II  | edo      | SM8250 |
+| `61.x.A.x.xxx` | Xperia 1 III, 5 III | sagami   | SM8350 |
+| `62.x.A.x.xxx` | Xperia 10 III       | lena     | SM6350 |
+| `64.x.A.x.xxx` | Xperia 1 IV, 5 IV   | nagara   | SM8450 |
+| `65.x.A.x.xxx` | Xperia 10 IV        | murray   | SM6375 |
+| `67.x.A.x.xxx` | Xperia 1 V          | yodo     | SM8550 |
+| `68.x.A.x.xxx` | Xperia 10 V         | zambezi  | SM6375 |
+| `69.x.A.x.xxx` | Xperia 1 VI         | asahi    | SM8650 |
+| `70.x.A.x.xxx` | Xperia 10 VI        | columbia | SM6450 |


### PR DESCRIPTION
They simply follow up with `69.x.A` and `70.x.A` respectively.  Device names are PDX245 (XQ-EC54) and PDX246 (XQ-ES54) respectively.

Branches are not pushed yet so we better wait with merging this until that's happened, but this way we at least have the necessary documentation.